### PR TITLE
Add support to concurrent requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,19 @@ AgonesSDK.set_annotation('version', '1.0.0')
 ```
 
 ## Player Tracking
+As players connect and disconnect from your game, the Player Tracking functions enable you to track which players are currently connected.
 
-As of writing, the Player Tracking feature of Agones is not implemented by the SDK. Feel free to contribute and send your pull request.
+### Player connect
+```GDScript
+# Sets player 1337 as connected
+AgonesSDK.player_connect(1337)
+```
+
+### Player disconnect
+```GDScript
+# Unsets player 1337 online status
+AgonesSDK.player_disconnect(1337)
+```
 
 ## Reference
 


### PR DESCRIPTION
## What?
- Adds support for concurrent HTTP requests to Agones sidecar
- Adds Player tracking support

## Why?
In the block below
```gdscript
func on_player_connected(caller_id : int) -> void:
    AgonesSDK.allocate()
    AgonesSDK.player_connect(str(caller_id)
    # Remaining operations....
```

The plugin throws an error
```
HTTPRequest is processing a request. Wait for completion
```
The suggestion (https://github.com/godotengine/godot/issues/16165) is to create an HTTP request node for each request.
