### PR TITLE
Fix/issue #9 stale endpoint on multiple requests

### DIFF
--- a/agones/agones_http_request.gd
+++ b/agones/agones_http_request.gd
@@ -1,0 +1,33 @@
+@tool
+extends HTTPRequest
+class_name AgonesHTTPRequest
+
+var _endpoint : String
+
+signal agones_request_completed(endpoint: String,
+								result: int, 
+								response_code: int, 
+								headers: PackedStringArray, 
+								body: PackedByteArray)
+								
+# Can't directly override built-in functions, but this is an override for HTTPRequest.request()
+func make_request(	endpoint: String = '',
+					custom_headers: PackedStringArray = PackedStringArray(),
+					method: int = 0, 
+					request_data: String = '') -> int:
+	if not AgonesSDK.isReady:
+		push_error('[AGONES] Trying to make agones request before SDK is ready')
+		return RESULT_NO_RESPONSE
+		
+	_endpoint = endpoint
+	self.request_completed.connect(_on_request_completed)
+	return super.request(sdk_url(endpoint), custom_headers, method, request_data)
+		
+func get_endpoint() -> String:
+	return _endpoint
+	
+static func sdk_url(endpoint) -> String:
+	return "http://%s:%s%s" % [AgonesSDK.get_host(), AgonesSDK.get_port(), endpoint]
+	
+func _on_request_completed(result: int, response_code: int, headers: PackedStringArray, body: PackedByteArray) -> void:
+	agones_request_completed.emit(_endpoint, result, response_code, headers, body)

--- a/agones/agones_sdk.gd
+++ b/agones/agones_sdk.gd
@@ -5,9 +5,9 @@ extends Node
 signal agones_response(success, endpoint, content)
 signal agones_ready_failed()
 
-var isReady = false
-var agones_sdk_http_port = ""
-var requested_endpoint = ""
+var isReady := false
+var agones_sdk_http_port := ""
+var agones_sdk_host := ""
 
 
 func _ready():
@@ -22,10 +22,14 @@ func start():
 	
 	isReady = true
 	agones_sdk_http_port = OS.get_environment("AGONES_SDK_HTTP_PORT")
+	agones_sdk_host = OS.get_environment("AGONES_SDK_HOST")
 	if agones_sdk_http_port == "":
 		print("[AGONES] AGONES_SDK_HTTP_PORT ENV NOT SET USING DEVELOPMENT PORT")
 		agones_sdk_http_port = "9358"
-	print("[AGONES] SDK STARTING UP... PORT FOUND: %s" % agones_sdk_http_port)
+	if agones_sdk_host == "":
+		print("[AGONES] AGONES_SDK_HOST ENV NOT SET USING DEVELOPMENT HOST")
+		agones_sdk_host = "localhost"
+	print("[AGONES] SDK STARTING UP... HOST: %s, PORT: %s" % [agones_sdk_host, agones_sdk_http_port])
 
 
 func ready(retry = 10, wait_time = 2.0):
@@ -116,36 +120,38 @@ func agones_sdk_send(endpoint: String, body: Dictionary, method = HTTPClient.MET
 		on_request_error()
 		return false
 	print("[AGONES] POST %s" % endpoint)
-	var headers = ["Content-Type: application/json"]
-	requested_endpoint = endpoint
+	var headers := ["Content-Type: application/json"]
 
-	var req = HTTPRequest.new()
+	var req := AgonesHTTPRequest.new()
 	add_child(req)
-	req.request_completed.connect(on_request_completed.bind(req))
-
-	var res = req.request(sdk_url(endpoint), headers, method, JSON.stringify(body))
+	req.agones_request_completed.connect(on_request_completed)
+	var res := req.make_request(endpoint, headers, method, JSON.stringify(body))
 	return true if res == OK else on_request_error(res)
 
 func on_request_error(error_code: int = 1) -> bool:
-	on_request_completed(error_code, 1, PackedStringArray(), PackedByteArray())
+	on_request_completed('', error_code, 1, PackedStringArray(), PackedByteArray())
 	return false
 
-func on_request_completed(result: int, response_code: int, _headers: PackedStringArray, body: PackedByteArray, req_node : HTTPRequest = null):
-	print("[AGONES] REQUESTED COMPLETED. RESPONSE_CODE: %d | CODE: %d" % [response_code, result])
+
+func on_request_completed(endpoint: String, result: int, response_code: int, _headers: PackedStringArray, body: PackedByteArray, req_node : HTTPRequest = null):
+	print("[AGONES] %s REQUESTED COMPLETED. RESPONSE_CODE: %d | CODE: %d" % [endpoint, response_code, result])
 	if result != OK:
-		emit_signal("agones_response", false, requested_endpoint, result)
+		agones_response.emit(false, endpoint, result)
 	else:
 		var dict_body = JSON.parse_string(body.get_string_from_utf8())
-		emit_signal("agones_response", true, requested_endpoint, dict_body)
-	requested_endpoint = ""
+		agones_response.emit(true, endpoint, dict_body)
 	
 	if req_node != null:
 		req_node.queue_free()
 
 
-func sdk_url(endpoint):
-	return "http://localhost:%s%s" % [agones_sdk_http_port, endpoint]
-
-
-func has_port():
+func has_port() -> bool:
 	return agones_sdk_http_port != ""
+
+
+func get_port() -> String:
+	return agones_sdk_http_port
+
+
+func get_host() -> String:
+	return agones_sdk_host


### PR DESCRIPTION
See #9 for details on bug.

# Solution
- Created configurable Agones host variable (based on environment variable similar to port).
- Added an HTTPRequest subclass `agones_http_request.gd` that tracks the endpoint the Agones request is made to.
- Wrote seudo-overloaded function for making requests.
- Moved endpoint url creation to subclass and it now builds dynamically from the ENV loaded on `agones_sdk.gd`
- Cleaned up how some signals were being connected so the LSP can track signal usage better (not all signals follow this pattern yet- could be part of another PR)

# Testing
Here is how I tested on the latest agones SDK (you may need to change how some of this works for the older version this plugin was built for):
```GDScript
AgonesSDK.gameserver()
AgonesSDK.health()
AgonesSDK.set_label("test-label", "test-value")
AgonesSDK.set_annotation("test-annotation", "test-value")
AgonesSDK.set_player_capacity(10)
AgonesSDK.get_player_capacity()
AgonesSDK.get_player_count()
AgonesSDK.get_connected_players()
AgonesSDK.player_connect("test-player-123")
AgonesSDK.player_disconnect("test-player-123")
AgonesSDK.is_player_connected("0", "test-player-123")
AgonesSDK.allocate()
AgonesSDK.reserve(60)
```
Ensure each endpoint returns 200 in your environment after Agones is all initialized. You can also try running the test case from the original issue to confirm that is fixed as well.

My dev setup runs the latest Agones which has different paths for the alpha endpoints. You may have mixed results testing. See for new endpoints: https://agones.dev/site/docs/guides/client-sdks/rest/

I think we'll need another separate PR for the new beta API endpoints.