### PR TITLE
feat: Counters & Lists (Beta) support · Add Counters & Lists for player tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,52 @@ AgonesSDK.player_connect(1337)
 AgonesSDK.player_disconnect(1337)
 ```
 
+## Counters & Lists (Beta)
+
+[Counters and Lists](https://agones.dev/site/docs/guides/counters-and-lists/) let you track
+arbitrary numeric counters and string lists on your GameServer (player tracking, team slots,
+etc). These are **Beta** Agones features and require **Agones 1.37+** (enabled by default since 1.45).
+
+Like the rest of the SDK, every call is asynchronous and reports back through the
+`agones_response(success, endpoint, content)` signal. For reads, `content` is the
+returned `Counter` (`{name, count, capacity}`) or `List` (`{name, capacity, values}`).
+
+### Lists
+
+```GDScript
+# Add a value to a list (e.g. mark a player as connected)
+AgonesSDK.append_list_value("players", "player-123")
+
+# Remove a value from a list
+AgonesSDK.delete_list_value("players", "player-123")
+
+# Read a list
+var result = await AgonesSDK.get_list("players")
+# result[2] -> { "name": "players", "capacity": 64, "values": ["player-123"] }
+
+# Set the maximum capacity of a list
+AgonesSDK.set_list_capacity("players", 64)
+```
+
+> `add_list_value` / `remove_list_value` are available as aliases matching the
+> Agones REST endpoint names (`:addValue` / `:removeValue`).
+
+### Counters
+
+```GDScript
+# Increment / decrement a counter (defaults to 1)
+AgonesSDK.increment_counter("rooms")
+AgonesSDK.decrement_counter("rooms", 2)
+
+# Set an absolute count or capacity
+AgonesSDK.set_counter_count("rooms", 5)
+AgonesSDK.set_counter_capacity("rooms", 10)
+
+# Read a counter
+var result = await AgonesSDK.get_counter("rooms")
+# result[2] -> { "name": "rooms", "count": 5, "capacity": 10 }
+```
+
 ## Reference
 
 | Type | Syntax | Description |
@@ -163,6 +209,15 @@ AgonesSDK.player_disconnect(1337)
 | `func` | `.reserve(seconds)` | Reserve for `seconds` |
 | `func` | `.allocate()` | Set GameServer as Allocated |
 | `func` | `.shutdown()` | Tells Agones to shutdown server |
+| `func` | `.get_counter(name)` | Get a Counter. Response `content` is `{name, count, capacity}` |
+| `func` | `.increment_counter(name, amount = 1)` | Increase a Counter's count by `amount` |
+| `func` | `.decrement_counter(name, amount = 1)` | Decrease a Counter's count by `amount` |
+| `func` | `.set_counter_count(name, count)` | Set a Counter's count to an absolute value |
+| `func` | `.set_counter_capacity(name, capacity)` | Set a Counter's maximum capacity |
+| `func` | `.get_list(name)` | Get a List. Response `content` is `{name, capacity, values}` |
+| `func` | `.append_list_value(name, value)` | Add `value` to a List (alias: `add_list_value`) |
+| `func` | `.delete_list_value(name, value)` | Remove `value` from a List (alias: `remove_list_value`) |
+| `func` | `.set_list_capacity(name, capacity)` | Set a List's maximum capacity |
 | `signal` | `agones_response(success, endpoint, content)` | Emitted when SDK receives an response from Agones. `success` Boolean if response is sucessfull. `endpoint` the requested endpoint. `content` the error message or request body, usually as a Dictionary |
 | `signal` | `agones_ready_failed` | Emitted when `.ready` fails all its attempts.  |
 

--- a/agones/agones_sdk.gd
+++ b/agones/agones_sdk.gd
@@ -97,7 +97,65 @@ func set_label(key: String, value: String):
 func set_annotation(key: String, value: String):
 	agones_sdk_put("/metadata/annotation", {"key": key, "value": value})
 
-	
+
+# --- Counters (Beta) ---
+# See https://agones.dev/site/docs/guides/counters-and-lists/
+
+func get_counter(name: String) -> bool:
+	return agones_sdk_get("/v1beta1/counters/" + name)
+
+
+func increment_counter(name: String, amount: int = 1) -> bool:
+	return _update_counter(name, {"countDiff": amount})
+
+
+func decrement_counter(name: String, amount: int = 1) -> bool:
+	return _update_counter(name, {"countDiff": -amount})
+
+
+func set_counter_count(name: String, count: int) -> bool:
+	return _update_counter(name, {"count": count})
+
+
+func set_counter_capacity(name: String, capacity: int) -> bool:
+	return _update_counter(name, {"capacity": capacity})
+
+
+func _update_counter(name: String, fields: Dictionary) -> bool:
+	var body := {"name": name}
+	body.merge(fields)
+	return agones_sdk_patch("/v1beta1/counters/" + name, body)
+
+
+# --- Lists (Beta) ---
+
+func get_list(name: String) -> bool:
+	return agones_sdk_get("/v1beta1/lists/" + name)
+
+
+func append_list_value(name: String, value: String) -> bool:
+	return agones_sdk_post("/v1beta1/lists/" + name + ":addValue", {"value": value})
+
+
+func delete_list_value(name: String, value: String) -> bool:
+	return agones_sdk_post("/v1beta1/lists/" + name + ":removeValue", {"value": value})
+
+
+# Aliases mirroring the Agones REST endpoint names (:addValue / :removeValue)
+func add_list_value(name: String, value: String) -> bool:
+	return append_list_value(name, value)
+
+
+func remove_list_value(name: String, value: String) -> bool:
+	return delete_list_value(name, value)
+
+
+func set_list_capacity(name: String, capacity: int) -> bool:
+	# UpdateList requires a field mask telling Agones which fields to apply.
+	var endpoint := "/v1beta1/lists/" + name + "?updateMask=capacity"
+	return agones_sdk_patch(endpoint, {"name": name, "capacity": capacity})
+
+
 func agones_sdk_get(endpoint: String) -> bool:
 	if not has_port():
 		print("[AGONES] AGONES_SDK_HTTP_PORT not found. skipping %s call" % endpoint)
@@ -112,6 +170,10 @@ func agones_sdk_post(endpoint: String, body: Dictionary) -> bool:
 
 func agones_sdk_put(endpoint: String, body: Dictionary) -> bool:
 	return agones_sdk_send(endpoint, body, HTTPClient.METHOD_PUT)
+
+
+func agones_sdk_patch(endpoint: String, body: Dictionary) -> bool:
+	return agones_sdk_send(endpoint, body, HTTPClient.METHOD_PATCH)
 
 
 func agones_sdk_send(endpoint: String, body: Dictionary, method = HTTPClient.METHOD_POST) -> bool:

--- a/agones/agones_sdk.gd
+++ b/agones/agones_sdk.gd
@@ -124,9 +124,13 @@ func agones_sdk_send(endpoint: String, body: Dictionary, method = HTTPClient.MET
 
 	var req := AgonesHTTPRequest.new()
 	add_child(req)
-	req.agones_request_completed.connect(on_request_completed)
+	req.agones_request_completed.connect(on_request_completed.bind(req))
 	var res := req.make_request(endpoint, headers, method, JSON.stringify(body))
-	return true if res == OK else on_request_error(res)
+	if res == OK:
+		return true
+	# make_request never fired the completion signal, so free the node here.
+	req.queue_free()
+	return on_request_error(res)
 
 func on_request_error(error_code: int = 1) -> bool:
 	on_request_completed('', error_code, 1, PackedStringArray(), PackedByteArray())


### PR DESCRIPTION
## What this PR adds

  Two independent commits:

  ### 1. `fix:` free `AgonesHTTPRequest` nodes after each request
  Each request adds an `AgonesHTTPRequest` as a child of the `AgonesSDK` autoload
  but it was never freed: `on_request_completed`'s `req_node` argument was never
  bound, so the `queue_free()` branch was dead code. On a long-running server
  (player tracking fires on every connect/disconnect) these nodes accumulate.
  This binds the node into the completion callback and also frees it on the
  `make_request` error path (where the completion signal never fires).

  ### 2. `feat:` Counters & Lists (Beta)
  New methods, reusing the existing `agones_sdk_send` → `AgonesHTTPRequest` →
  `agones_response` pattern (adds an `agones_sdk_patch` helper for `METHOD_PATCH`):

  **Counters**
  - `get_counter(name)`
  - `increment_counter(name, amount = 1)` / `decrement_counter(name, amount = 1)`
  - `set_counter_count(name, count)` / `set_counter_capacity(name, capacity)`

  **Lists**
  - `get_list(name)`
  - `append_list_value(name, value)` / `delete_list_value(name, value)`
    (with `add_list_value` / `remove_list_value` aliases that mirror the REST
    endpoint names)
  - `set_list_capacity(name, capacity)`

  Method names follow the other Agones SDKs (`AppendListValue` / `DeleteListValue`)
  so cross-engine docs stay consistent. README updated with examples and the
  reference table.
  
  ## Notes

  - Endpoints/field names verified against `proto/sdk/beta/beta.proto` on `main`
    (e.g. `UpdateList` requires the `updateMask` field mask; `count`/`capacity`
    are `Int64Value`, so they're only sent when set).
  - Counters & Lists is a **Beta** Agones feature and requires **Agones 1.37+**.
  - No breaking changes, purely additive plus the leak fix.